### PR TITLE
Alpine CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Install required tools
-          command: pacman -Sy --noconfirm base base-devel git python python-json5 python-pycryptodome python-tornado
+          command: pacman -Sy --noconfirm python python-pycryptodome python-tornado
       - run:
           name: Unit Test
           command: ./scripts/test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: archlinux
+      - image: alpine
 
     steps:
       - checkout
       - run:
           name: Install required tools
-          command: pacman -Sy --noconfirm python python-pycryptodome python-tornado
+          command: apk add --no-cache bash python3 py3-tornado py3-pycryptodome openssl
       - run:
           name: Unit Test
           command: ./scripts/test.sh


### PR DESCRIPTION
### Changes
* Changes CI to use minimal Alpine linux image

### Examples
CI now takes 3 seconds to perform setup:
![image](https://user-images.githubusercontent.com/26678747/101288526-2001b580-37c5-11eb-9fa7-43c3c1d1bf00.png)

as opposed to 27 seconds on master:
![image](https://user-images.githubusercontent.com/26678747/101288563-3e67b100-37c5-11eb-90fb-a5c364649d61.png)

for a 9x speedup!